### PR TITLE
修改拼写错误，food页面排序问题

### DIFF
--- a/src/components/common/computeTime.vue
+++ b/src/components/common/computeTime.vue
@@ -78,7 +78,7 @@
 	.page{
         display: inline-block;
         .rem_time{
-            @include sc(.55rem, #orange);
+            @include sc(.55rem, orange);
             padding: .1rem .2rem;
             border-radius: .15rem;
         }

--- a/src/page/food/food.vue
+++ b/src/page/food/food.vue
@@ -38,7 +38,7 @@
 	    					</ul>
 	    				</section>
 	    			</section>
-	    		</transition>	
+	    		</transition>
     		</div>
     		<div class="sort_item" :class="{choose_type:sortBy == 'sort'}">
     			<div class="sort_item_container" @click="chooseType('sort')">
@@ -120,7 +120,7 @@
 	    					</li>
 	    				</ul>
 	    			</section>
-	    		</transition>	
+	    		</transition>
     		</div>
     		<div class="sort_item" :class="{choose_type:sortBy == 'activity'}">
     			<div class="sort_item_container" @click="chooseType('activity')">
@@ -168,7 +168,7 @@
     	<section class="shop_list_container">
 	    	<shop-list :geohash="geohash" :restaurantCategoryId="restaurant_category_id" :restaurantCategoryIds="restaurant_category_ids" :sortByType='sortByType' :deliveryMode="delivery_mode" :confirmSelect="confirmStatus" :supportIds="support_ids" v-if="latitude" @DidConfrim="clearAll"></shop-list>
     	</section>
-    </div>    
+    </div>
 </template>
 
 <script>
@@ -222,7 +222,7 @@ export default {
 			this.headTitle = this.$route.query.title;
 			this.foodTitle = this.headTitle;
 			this.restaurant_category_id = this.$route.query.restaurant_category_id;
-			//防止刷新页面时，vuex状态丢失，经度纬度需要重新获取，并存入vuex	
+			//防止刷新页面时，vuex状态丢失，经度纬度需要重新获取，并存入vuex
 			if (!this.latitude) {
 		    	//获取位置信息
 		    	let res = await msiteAddress(this.geohash);
@@ -288,8 +288,14 @@ export default {
 		},
 		//点击某个排序方式，获取事件对象的data值，并根据获取的值重新获取数据渲染
 		sortList(event){
-			console.log(this.filterNum)
-			this.sortByType = event.target.getAttribute('data');
+      let node;
+      // 如果点击的是 span 中的文字，则需要获取到 span 的父标签 p
+      if (event.target.nodeName.toUpperCase() !== 'P') {
+        node = event.target.parentNode;
+      } else {
+        node = event.target;
+      }
+      this.sortByType = node.getAttribute('data');
 			this.sortBy = '';
 		},
 		//筛选选项中的配送方式选择
@@ -327,8 +333,9 @@ export default {
 		},
 		//只有点击清空按钮才清空数据，否则一直保持原有状态
 		clearSelect(){
-            this.support_ids.map(item => item.status = false);
-            this.filterNum = 0;
+      this.support_ids.map(item => item.status = false);
+      this.filterNum = 0;
+      this.delivery_mode = null;
 		},
 		//点击确认时，将需要筛选的id值传递给子组件，并且收回列表
 		confirmSelectFun(){
@@ -378,7 +385,7 @@ export default {
 				transition: all .3s;
 				fill:#666;
 			}
-			
+
 		}
 		.choose_type{
 			.sort_item_container{

--- a/src/page/food/food.vue
+++ b/src/page/food/food.vue
@@ -176,7 +176,7 @@ import {mapState, mapMutations} from 'vuex'
 import headTop from 'src/components/header/head'
 import shopList from 'src/components/common/shoplist'
 import {getImgPath} from 'src/components/common/mixin'
-import {msiteAdress, foodCategory, foodDelivery, foodActivity} from 'src/service/getData'
+import {msiteAddress, foodCategory, foodDelivery, foodActivity} from 'src/service/getData'
 
 export default {
 	data(){
@@ -225,7 +225,7 @@ export default {
 			//防止刷新页面时，vuex状态丢失，经度纬度需要重新获取，并存入vuex	
 			if (!this.latitude) {
 		    	//获取位置信息
-		    	let res = await msiteAdress(this.geohash);
+		    	let res = await msiteAddress(this.geohash);
 		    	// 记录当前经度纬度进入vuex
 			    this.RECORD_ADDRESS(res);
 			}

--- a/src/page/login/login.vue
+++ b/src/page/login/login.vue
@@ -21,7 +21,7 @@
                 <input v-if="!showPassword" type="password" placeholder="密码"  v-model="passWord">
                 <input v-else type="text" placeholder="密码"  v-model="passWord">
                 <div class="button_switch" :class="{change_to_text: showPassword}">
-                    <div class="circel_button" :class="{trans_to_right: showPassword}" @click="changePassWordType"></div>
+                    <div class="circle_button" :class="{trans_to_right: showPassword}" @click="changePassWordType"></div>
                     <span>abc</span>
                     <span>...</span>
                 </div>
@@ -278,7 +278,7 @@
         border: 1px;
         border-radius: 0.5rem;
         position: relative;
-        .circel_button{
+        .circle_button{
             transition: all .3s;
             position: absolute;
             top: -0.2rem;

--- a/src/page/msite/msite.vue
+++ b/src/page/msite/msite.vue
@@ -8,7 +8,7 @@
 	    		</svg>
     		</router-link>
 			<router-link to="/home" slot="msite-title" class="msite_title">
-				<span class="title_text ellipsis">{{msietTitle}}</span>
+				<span class="title_text ellipsis">{{msiteTitle}}</span>
 			</router-link>
     	</head-top>
     	<nav class="msite_nav">
@@ -46,7 +46,7 @@ import {mapMutations} from 'vuex'
 import headTop from 'src/components/header/head'
 import footGuide from 'src/components/footer/footGuide'
 import shopList from 'src/components/common/shoplist'
-import {msiteAdress, msiteFoodTypes, cityGuess} from 'src/service/getData'
+import {msiteAddress, msiteFoodTypes, cityGuess} from 'src/service/getData'
 import 'src/plugins/swiper.min.js'
 import 'src/style/swiper.min.css'
 
@@ -54,7 +54,7 @@ export default {
 	data(){
         return {
         	geohash: '', // city页面传递过来的地址geohash
-            msietTitle: '请选择地址...', // msiet页面头部标题
+            msiteTitle: '请选择地址...', // msite页面头部标题
             foodTypes: [], // 食品分类列表
             hasGetData: false, //是否已经获取地理位置数据，成功之后再获取商铺列表信息
             imgBaseUrl: 'https://fuss10.elemecdn.com', //图片域名地址
@@ -70,8 +70,8 @@ export default {
 		//保存geohash 到vuex
 		this.SAVE_GEOHASH(this.geohash);
     	//获取位置信息
-    	let res = await msiteAdress(this.geohash);
-    	this.msietTitle = res.name;
+    	let res = await msiteAddress(this.geohash);
+    	this.msiteTitle = res.name;
     	// 记录当前经度纬度
     	this.RECORD_ADDRESS(res);
 

--- a/src/page/shop/shop.vue
+++ b/src/page/shop/shop.vue
@@ -317,7 +317,7 @@
 
 <script>
     import {mapState, mapMutations} from 'vuex'
-    import {msiteAdress, shopDetails, foodMenu, getRatingList, ratingScores, ratingTags} from 'src/service/getData'
+    import {msiteAddress, shopDetails, foodMenu, getRatingList, ratingScores, ratingTags} from 'src/service/getData'
     import loading from 'src/components/common/loading'
     import buyCart from 'src/components/common/buyCart'
     import ratingStar from 'src/components/common/ratingStar'
@@ -427,7 +427,7 @@
             async initData(){
                 if (!this.latitude) {
                     //获取位置信息
-                    let res = await msiteAdress(this.geohash);
+                    let res = await msiteAddress(this.geohash);
                     // 记录当前经度纬度进入vuex
                     this.RECORD_ADDRESS(res);
                 }

--- a/src/service/getData.js
+++ b/src/service/getData.js
@@ -50,7 +50,7 @@ export const searchplace = (cityid, value) => fetch('/v1/pois', {
  * 获取msite页面地址信息
  */
 
-export const msiteAdress = geohash => fetch('/v2/pois/' + geohash);
+export const msiteAddress = geohash => fetch('/v2/pois/' + geohash);
 
 
 /**


### PR DESCRIPTION
1. 修改相关单词错误拼写的问题
2. 修改`food`页面中点击排序中的文字无法排序的问题
    - 文字属于`span`标签内的内容，不包含`data`属性，导致点击文字无法获取到排序值
3. 修改`food`页面中筛选，点击清空未修改配送方式的状态
   - 选中`蜂鸟派送`后选择清空，`蜂鸟派送`没有被取消选择，这时再点击`蜂鸟配送`，确认后面是`(-1)`