### PR TITLE
配置代理

### DIFF
--- a/src/config/vue.config.js
+++ b/src/config/vue.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  devServer: {
+    proxy: {
+      // 配置代理
+      '/api': {
+        target: "https://elm.cangdu.org",
+        secure: true,
+        changeOrigin: true,
+        ws: true,
+        pathRewrite: { '^/api': '', }
+      }
+    }
+  }
+};


### PR DESCRIPTION
配置代理解决axios请求携带不了cookie的问题，在config目录下添加了vue.config.js文件